### PR TITLE
Fix/zenn

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -57,6 +57,7 @@ type PlatformUserInfo struct {
 	FollowersCount int
 	FollowingCount int
 	ArticlesCount  int
+	LikeCount      int // Zenn用のフィールド
 	Rating         int // AtCoder用のフィールド
 }
 
@@ -125,7 +126,13 @@ func (s *Server) SVGHandler(w http.ResponseWriter, r *http.Request) {
 	// 統計情報
 	canvas.Text(130+strokeWidth, 25+strokeWidth, fmt.Sprintf("@%s", username), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 	canvas.Text(130+strokeWidth, 50+strokeWidth, fmt.Sprintf("Followers: %d", userInfo.FollowersCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
-	canvas.Text(130+strokeWidth, 75+strokeWidth, fmt.Sprintf("Following: %d", userInfo.FollowingCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
+
+	if platform != "zenn" {
+		canvas.Text(130+strokeWidth, 75+strokeWidth, fmt.Sprintf("Following: %d", userInfo.FollowingCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
+	} else {
+		canvas.Text(130+strokeWidth, 75+strokeWidth, fmt.Sprintf("Likes: %d", userInfo.LikeCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
+	}
+
 	canvas.Text(130+strokeWidth, 100+strokeWidth, fmt.Sprintf("Posts: %d", userInfo.ArticlesCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 
 	// AtCoderの場合はRatingも表示
@@ -217,7 +224,7 @@ func fetchZennData(username string) (*PlatformUserInfo, error) {
 	var user struct {
 		User struct {
 			FollowersCount int `json:"follower_count"`
-			FollowingCount int `json:"following_count"`
+			LikeCount      int `json:"total_liked_count"`
 			ArticlesCount  int `json:"articles_count"`
 		} `json:"user"`
 	}
@@ -231,7 +238,7 @@ func fetchZennData(username string) (*PlatformUserInfo, error) {
 
 	return &PlatformUserInfo{
 		FollowersCount: user.User.FollowersCount,
-		FollowingCount: user.User.FollowingCount,
+		LikeCount:      user.User.LikeCount,
 		ArticlesCount:  user.User.ArticlesCount,
 	}, nil
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -215,8 +215,11 @@ func fetchZennData(username string) (*PlatformUserInfo, error) {
 	defer resp.Body.Close()
 
 	var user struct {
-		FollowersCount int `json:"followers_count"`
-		ArticlesCount  int `json:"articles_count"`
+		User struct {
+			FollowersCount int `json:"follower_count"`
+			FollowingCount int `json:"following_count"`
+			ArticlesCount  int `json:"articles_count"`
+		} `json:"user"`
 	}
 
 	fmt.Println(resp.Body)
@@ -227,9 +230,9 @@ func fetchZennData(username string) (*PlatformUserInfo, error) {
 	}
 
 	return &PlatformUserInfo{
-		FollowersCount: user.FollowersCount,
-		FollowingCount: 0, // Zenn APIにはフォロー中のユーザー数がないため、0を返します
-		ArticlesCount:  user.ArticlesCount,
+		FollowersCount: user.User.FollowersCount,
+		FollowingCount: user.User.FollowingCount,
+		ArticlesCount:  user.User.ArticlesCount,
 	}, nil
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -112,25 +112,25 @@ func (s *Server) SVGHandler(w http.ResponseWriter, r *http.Request) {
 	canvas.Link(url, "")
 
 	// 外枠を描画
-	canvas.Rect(strokeWidth, strokeWidth, width, height, 
+	canvas.Rect(strokeWidth, strokeWidth, width, height,
 		fmt.Sprintf("fill:none;rx:%d;ry:%d;stroke:%s;stroke-width:%d", borderRadius, borderRadius, platformColors[platform], strokeWidth))
 
 	// 背景（角丸の長方形）
-	canvas.Rect(strokeWidth, strokeWidth, width, height, 
+	canvas.Rect(strokeWidth, strokeWidth, width, height,
 		fmt.Sprintf("fill:%s;rx:%d;ry:%d", platformBgColors[platform], borderRadius, borderRadius))
 
 	// アイコン
-	canvas.Image(20 + strokeWidth, 20 + strokeWidth, 80, 80, iconURL)
+	canvas.Image(20+strokeWidth, 20+strokeWidth, 80, 80, iconURL)
 
 	// 統計情報
-	canvas.Text(130 + strokeWidth, 25 + strokeWidth, fmt.Sprintf("@%s", username), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
-	canvas.Text(130 + strokeWidth, 50 + strokeWidth, fmt.Sprintf("Followers: %d", userInfo.FollowersCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
-	canvas.Text(130 + strokeWidth, 75 + strokeWidth, fmt.Sprintf("Following: %d", userInfo.FollowingCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
-	canvas.Text(130 + strokeWidth, 100 + strokeWidth, fmt.Sprintf("Posts: %d", userInfo.ArticlesCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
+	canvas.Text(130+strokeWidth, 25+strokeWidth, fmt.Sprintf("@%s", username), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
+	canvas.Text(130+strokeWidth, 50+strokeWidth, fmt.Sprintf("Followers: %d", userInfo.FollowersCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
+	canvas.Text(130+strokeWidth, 75+strokeWidth, fmt.Sprintf("Following: %d", userInfo.FollowingCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
+	canvas.Text(130+strokeWidth, 100+strokeWidth, fmt.Sprintf("Posts: %d", userInfo.ArticlesCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 
 	// AtCoderの場合はRatingも表示
 	if platform == "atcoder" {
-		canvas.Text(120 + strokeWidth, 130 + strokeWidth, fmt.Sprintf("Rating: %d", userInfo.Rating), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
+		canvas.Text(120+strokeWidth, 130+strokeWidth, fmt.Sprintf("Rating: %d", userInfo.Rating), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 	}
 
 	// リンクの終了
@@ -216,6 +216,9 @@ func fetchZennData(username string) (*PlatformUserInfo, error) {
 		ArticlesCount  int `json:"articles_count"`
 	}
 
+	fmt.Println(resp.Body)
+	fmt.Println(user)
+
 	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
 		return nil, err
 	}
@@ -242,8 +245,8 @@ func fetchStackoverflowData(username string) (*PlatformUserInfo, error) {
 
 	var response struct {
 		Items []struct {
-			Reputation   int `json:"reputation"`
-			AnswerCount  int `json:"answer_count"`
+			Reputation    int `json:"reputation"`
+			AnswerCount   int `json:"answer_count"`
 			QuestionCount int `json:"question_count"`
 		} `json:"items"`
 	}
@@ -259,8 +262,8 @@ func fetchStackoverflowData(username string) (*PlatformUserInfo, error) {
 	user := response.Items[0]
 
 	return &PlatformUserInfo{
-		FollowersCount: user.Reputation,   // StackOverflowではReputationをFollowersCountとして代用
-		FollowingCount: 0,                 // StackOverflow APIにはフォロー中のユーザー数がないため、0を返します
+		FollowersCount: user.Reputation,                       // StackOverflowではReputationをFollowersCountとして代用
+		FollowingCount: 0,                                     // StackOverflow APIにはフォロー中のユーザー数がないため、0を返します
 		ArticlesCount:  user.AnswerCount + user.QuestionCount, // 回答数と質問数の合計を投稿数として扱います
 	}, nil
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -127,13 +127,17 @@ func (s *Server) SVGHandler(w http.ResponseWriter, r *http.Request) {
 	canvas.Text(130+strokeWidth, 25+strokeWidth, fmt.Sprintf("@%s", username), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 	canvas.Text(130+strokeWidth, 50+strokeWidth, fmt.Sprintf("Followers: %d", userInfo.FollowersCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 
-	if platform != "zenn" {
-		canvas.Text(130+strokeWidth, 75+strokeWidth, fmt.Sprintf("Following: %d", userInfo.FollowingCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
-	} else {
+	if platform == "zenn" {
 		canvas.Text(130+strokeWidth, 75+strokeWidth, fmt.Sprintf("Likes: %d", userInfo.LikeCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
+	} else {
+		canvas.Text(130+strokeWidth, 75+strokeWidth, fmt.Sprintf("Following: %d", userInfo.FollowingCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 	}
 
-	canvas.Text(130+strokeWidth, 100+strokeWidth, fmt.Sprintf("Posts: %d", userInfo.ArticlesCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
+	if platform == "zenn" {
+		canvas.Text(130+strokeWidth, 100+strokeWidth, fmt.Sprintf("Articles: %d", userInfo.ArticlesCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
+	} else {
+		canvas.Text(130+strokeWidth, 100+strokeWidth, fmt.Sprintf("Posts: %d", userInfo.ArticlesCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
+	}
 
 	// AtCoderの場合はRatingも表示
 	if platform == "atcoder" {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -206,8 +206,11 @@ func fetchTwitterData(username string) (*PlatformUserInfo, error) {
 
 func fetchZennData(username string) (*PlatformUserInfo, error) {
 	resp, err := http.Get(fmt.Sprintf("https://zenn.dev/api/users/%s", username))
-	if err != nil || resp.StatusCode != http.StatusOK {
+	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("user not found")
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
## 処理概要

- zennのAPIを叩いた時に404になった時のエラーハンドリングを変更
- APIの戻り値の形式が間違っているのを変更
- zennの場合、followingでなくlikesを表示するように変更

## 要件・仕様

- まともに表示できるように

## 動作確認

ブラウザで直接確認
