### PR TITLE
faet:youtube

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -8,6 +8,7 @@ var PlatformIcons = map[string]string{
 	"stackoverflow": "/assets/stackoverflow.png",
 	"atcoder":       "/assets/atcoder.png",
 	"note":          "/assets/note.png",
+	"youtube":       "/assets/youtube.png",
 }
 
 var PlatformURLs = map[string]string{
@@ -18,6 +19,7 @@ var PlatformURLs = map[string]string{
 	"stackoverflow": "https://stackoverflow.com/users/",
 	"atcoder":       "https://atcoder.jp/users/",
 	"note":          "https://note.com/",
+	"youtube":       "https://youtube.com/",
 }
 
 var PlatformColors = map[string]string{
@@ -28,6 +30,7 @@ var PlatformColors = map[string]string{
 	"stackoverflow": "#F48024",
 	"atcoder":       "#000000",
 	"note":          "#00A7AF",
+	"youtube":       "#FF0000",
 }
 
 var PlatformBgColors = map[string]string{
@@ -38,6 +41,7 @@ var PlatformBgColors = map[string]string{
 	"stackoverflow": "#FFFFFB",
 	"atcoder":       "#EBEBEB",
 	"note":          "#F5F5F5",
+	"youtube":       "#FFFFFF",
 }
 
 var PlatformFontColors = map[string]string{
@@ -48,6 +52,7 @@ var PlatformFontColors = map[string]string{
 	"stackoverflow": "#000000",
 	"atcoder":       "#000000",
 	"note":          "#000000",
+	"youtube":       "#000000",
 }
 
 type PlatformUserInfo struct {
@@ -60,4 +65,6 @@ type PlatformUserInfo struct {
 	AnswerCount    int    // StackOverflow用のフィールド
 	QuestionCount  int    // StackOverflow用のフィールド
 	Rating         int    // AtCoder用のフィールド
+	TotalVideos    int    // Youtube用のフィールド
+	TotalViewCount int    // Youtube用のフィールド
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -65,6 +65,7 @@ type PlatformUserInfo struct {
 	AnswerCount    int    // StackOverflow用のフィールド
 	QuestionCount  int    // StackOverflow用のフィールド
 	Rating         int    // AtCoder用のフィールド
+	CustomURL      string // Youtube用のフィールド
 	TotalVideos    int    // Youtube用のフィールド
 	TotalViewCount int    // Youtube用のフィールド
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -37,12 +37,17 @@ func (s *Server) SVGHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	url := urlBase + username
-
 	userInfo, err := fetchUserData(platform, username)
 	if err != nil {
 		handleError(w, err, http.StatusInternalServerError, fmt.Sprintf("Failed to fetch data from %s", platform))
 		return
+	}
+
+	var url string
+	if platform == "youtube" {
+		url = urlBase + userInfo.CustomURL
+	} else {
+		url = urlBase + username
 	}
 
 	// SVGの生成
@@ -73,7 +78,7 @@ func (s *Server) SVGHandler(w http.ResponseWriter, r *http.Request) {
 
 	// 統計情報
 	if platform == "stackoverflow" || platform == "note" || platform == "youtube" {
-		canvas.Text(130+strokeWidth, 25+strokeWidth, fmt.Sprintf("@%s", userInfo.UserName), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
+		canvas.Text(130+strokeWidth, 25+strokeWidth, fmt.Sprintf(userInfo.UserName), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 	} else {
 		canvas.Text(130+strokeWidth, 25+strokeWidth, fmt.Sprintf("@%s", username), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 	}
@@ -92,7 +97,7 @@ func (s *Server) SVGHandler(w http.ResponseWriter, r *http.Request) {
 			canvas.Text(130+strokeWidth, 75+strokeWidth, fmt.Sprintf("Answers: %d", userInfo.AnswerCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 		}
 		} else if platform == "youtube" {
-			canvas.Text(130+strokeWidth, 100+strokeWidth, fmt.Sprintf("Videos: %d", userInfo.TotalVideos), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
+			canvas.Text(130+strokeWidth, 75+strokeWidth, fmt.Sprintf("Videos: %d", userInfo.TotalVideos), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 	} else {
 		canvas.Text(130+strokeWidth, 75+strokeWidth, fmt.Sprintf("Following: %d", userInfo.FollowingCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -72,7 +72,7 @@ func (s *Server) SVGHandler(w http.ResponseWriter, r *http.Request) {
 	canvas.Image(20+strokeWidth, 20+strokeWidth, 80, 80, iconURL)
 
 	// 統計情報
-	if platform == "stackoverflow" || platform == "note" {
+	if platform == "stackoverflow" || platform == "note" || platform == "youtube" {
 		canvas.Text(130+strokeWidth, 25+strokeWidth, fmt.Sprintf("@%s", userInfo.UserName), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 	} else {
 		canvas.Text(130+strokeWidth, 25+strokeWidth, fmt.Sprintf("@%s", username), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
@@ -91,6 +91,8 @@ func (s *Server) SVGHandler(w http.ResponseWriter, r *http.Request) {
 		} else {
 			canvas.Text(130+strokeWidth, 75+strokeWidth, fmt.Sprintf("Answers: %d", userInfo.AnswerCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 		}
+		} else if platform == "youtube" {
+			canvas.Text(130+strokeWidth, 100+strokeWidth, fmt.Sprintf("Videos: %d", userInfo.TotalVideos), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 	} else {
 		canvas.Text(130+strokeWidth, 75+strokeWidth, fmt.Sprintf("Following: %d", userInfo.FollowingCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 	}
@@ -103,6 +105,8 @@ func (s *Server) SVGHandler(w http.ResponseWriter, r *http.Request) {
 		} else {
 			canvas.Text(130+strokeWidth, 100+strokeWidth, fmt.Sprintf("Questions: %d", userInfo.QuestionCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 		}
+	} else if platform == "youtube" {
+		canvas.Text(130+strokeWidth, 100+strokeWidth, fmt.Sprintf("Views: %d", userInfo.TotalViewCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 	} else if platform == "note" {
 		canvas.Text(130+strokeWidth, 100+strokeWidth, fmt.Sprintf("Notes: %d", userInfo.ArticlesCount), fmt.Sprintf("font-family:Arial;font-size:14px;fill:%s", textColor))
 	} else {
@@ -135,6 +139,8 @@ func fetchUserData(platform, username string) (*model.PlatformUserInfo, error) {
 		return usecase.FetchAtCoderData(username)
 	case "note":
 		return usecase.FetchNoteData(username)
+	case "youtube":
+		return usecase.FetchYoutubeData(username)
 	}
 	return nil, fmt.Errorf("platform not supported")
 }

--- a/internal/usecase/fetch_youtube.go
+++ b/internal/usecase/fetch_youtube.go
@@ -41,6 +41,7 @@ func FetchYoutubeData(username string) (*model.PlatformUserInfo, error) {
 		Items []struct {
 			Snippet struct {
 				Username string `json:"title"`
+				CustomUrl string `json:"customUrl"`
 			} `json:"snippet"`
 			Statistics struct {
 				SubscriberCount string `json:"subscriberCount"`
@@ -64,12 +65,14 @@ func FetchYoutubeData(username string) (*model.PlatformUserInfo, error) {
 
 	stats := result.Items[0].Statistics
 
+	customURL := result.Items[0].Snippet.CustomUrl
 	username = result.Items[0].Snippet.Username
 	subscriberCount, _ := strconv.Atoi(stats.SubscriberCount)
 	viewCount, _ := strconv.Atoi(stats.ViewCount)
 	videoCount, _ := strconv.Atoi(stats.VideoCount)
 
 	platformUserInfo := &model.PlatformUserInfo{
+		CustomURL:      customURL,
 		UserName:       username,
 		FollowersCount: subscriberCount,
 		TotalVideos:    videoCount,

--- a/internal/usecase/fetch_youtube.go
+++ b/internal/usecase/fetch_youtube.go
@@ -1,0 +1,80 @@
+package usecase
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+
+	"profile/internal/model"
+)
+
+func FetchYoutubeData(username string) (*model.PlatformUserInfo, error) {
+	apiKey := os.Getenv("YOUTUBE_API_KEY")
+	if apiKey == "" {
+		return nil, fmt.Errorf("YOUTUBE_API_KEY is not set in .env")
+	}
+
+	channelName := fmt.Sprintf("https://www.googleapis.com/youtube/v3/channels?part=snippet&id=%s&key=%s", username, apiKey)
+	snippetResponse, err := http.Get(channelName)
+	if err != nil {
+		return nil, err
+	}
+	defer snippetResponse.Body.Close()
+
+	if snippetResponse.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch data: %s", snippetResponse.Status)
+	}
+	channelURL := fmt.Sprintf("https://www.googleapis.com/youtube/v3/channels?part=statistics&id=%s&key=%s", username, apiKey)
+	statisticsResponse, err := http.Get(channelURL)
+	if err != nil {
+		return nil, err
+	}
+	defer statisticsResponse.Body.Close()
+
+	if statisticsResponse.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch data: %s", statisticsResponse.Status)
+	}
+
+	var result struct {
+		Items []struct {
+			Snippet struct {
+				Username string `json:"title"`
+			} `json:"snippet"`
+			Statistics struct {
+				SubscriberCount string `json:"subscriberCount"`
+				ViewCount       string `json:"viewCount"`
+				VideoCount      string `json:"videoCount"`
+			} `json:"statistics"`
+		} `json:"items"`
+	}
+
+	if err := json.NewDecoder(snippetResponse.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	if err := json.NewDecoder(statisticsResponse.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	if len(result.Items) == 0 {
+		return nil, fmt.Errorf("no channel found for username: %s", username)
+	}
+
+	stats := result.Items[0].Statistics
+
+	username = result.Items[0].Snippet.Username
+	subscriberCount, _ := strconv.Atoi(stats.SubscriberCount)
+	viewCount, _ := strconv.Atoi(stats.ViewCount)
+	videoCount, _ := strconv.Atoi(stats.VideoCount)
+
+	platformUserInfo := &model.PlatformUserInfo{
+		UserName:       username,
+		FollowersCount: subscriberCount,
+		TotalVideos:    videoCount,
+		TotalViewCount: viewCount,
+	}
+
+	return platformUserInfo, nil
+}


### PR DESCRIPTION
## 処理概要
- YouTubeAPIから値を取得する処理を追加

## 要件・仕様
- チャンネル名、登録者数、投稿数、総再生回数を表示

## 動作確認
- フロントで動作確認済み